### PR TITLE
Make the game *run at all*

### DIFF
--- a/mods/thirst/mod.conf
+++ b/mods/thirst/mod.conf
@@ -1,3 +1,3 @@
 name = thirst
 description = Adds thirst and ways to quench it.
-depends = hudbars, ws_core, bucket
+depends = hudbars, ws_core

--- a/mods/ws_achievements/mod.conf
+++ b/mods/ws_achievements/mod.conf
@@ -1,4 +1,4 @@
 name = ws_achievements
 description = Achievement system for Wastelands Survival with GUI notifications
-depends = default, ws_story
+depends = ws_story
 optional_depends = mobs, farming, dewcollector

--- a/mods/ws_maps/init.lua
+++ b/mods/ws_maps/init.lua
@@ -539,21 +539,21 @@ end)
 
 -- Achievement integration
 if minetest.get_modpath("ws_achievements") then
-    achievements.register_achievement("cartographer", {
+    ws_achievements.register_achievement("cartographer", {
         title = "Cartographer",
         description = "Discover 100 map chunks",
         category = "exploration",
         icon = "ws_achievements_map.png"
     })
     
-    achievements.register_achievement("landmark_explorer", {
+    ws_achievements.register_achievement("landmark_explorer", {
         title = "Landmark Explorer", 
         description = "Discover 10 different landmarks",
         category = "exploration",
         icon = "ws_achievements_landmark.png"
     })
     
-    achievements.register_achievement("pathfinder", {
+    ws_achievements.register_achievement("pathfinder", {
         title = "Pathfinder",
         description = "Set 5 personal waypoints",
         category = "exploration", 

--- a/mods/ws_maps/mod.conf
+++ b/mods/ws_maps/mod.conf
@@ -1,0 +1,3 @@
+name = ws_maps
+description =
+optional_depends = ws_achievements

--- a/mods/ws_radiation/init.lua
+++ b/mods/ws_radiation/init.lua
@@ -301,7 +301,7 @@ minetest.after(0, radiation.check_players)
 
 -- Achievements integration
 if minetest.get_modpath("ws_achievements") then
-    achievements.register_achievement("radiation_survivor", {
+    ws_achievements.register_achievement("radiation_survivor", {
         title = "Radiation Survivor",
         description = "Survive your first high-radiation zone",
         category = "survival",
@@ -311,8 +311,8 @@ if minetest.get_modpath("ws_achievements") then
     -- Check for achievement
     minetest.register_globalstep(function(dtime)
         for player_name, data in pairs(radiation.players) do
-            if data.level >= 60 and not achievements.has_achievement(player_name, "radiation_survivor") then
-                achievements.grant_achievement(player_name, "radiation_survivor")
+            if data.level >= 60 and not ws_achievements.has_achievement(player_name, "radiation_survivor") then
+                ws_achievements.grant_achievement(player_name, "radiation_survivor")
             end
         end
     end)

--- a/mods/ws_radiation/mod.conf
+++ b/mods/ws_radiation/mod.conf
@@ -1,0 +1,3 @@
+name = ws_radiation
+description =
+optional_depends = ws_achievements

--- a/mods/ws_ruins/init.lua
+++ b/mods/ws_ruins/init.lua
@@ -561,14 +561,14 @@ minetest.register_chatcommand("build_ruin", {
 
 -- Achievement integration
 if minetest.get_modpath("ws_achievements") then
-    achievements.register_achievement("ruin_explorer", {
+    ws_achievements.register_achievement("ruin_explorer", {
         title = "Ruin Explorer",
         description = "Discover and explore 5 different ruins",
         category = "exploration",
         icon = "ws_achievements_ruins.png"
     })
     
-    achievements.register_achievement("treasure_hunter", {
+    ws_achievements.register_achievement("treasure_hunter", {
         title = "Treasure Hunter", 
         description = "Find loot in 10 different ruin chests",
         category = "exploration",

--- a/mods/ws_ruins/mod.conf
+++ b/mods/ws_ruins/mod.conf
@@ -1,0 +1,3 @@
+name = ws_ruins
+description =
+optional_depends = ws_achievements

--- a/mods/ws_story/init.lua
+++ b/mods/ws_story/init.lua
@@ -224,6 +224,8 @@ local creature_encounters = {
 
 -- Register all creature encounters
 for mob, data in pairs(creature_encounters) do
+    ---#FIXME
+    --[[
     triggers.register_on_punch({
         target = {mob},
         id = "ws_story:" .. mob,
@@ -233,6 +235,7 @@ for mob, data in pairs(creature_encounters) do
             entries.add_entry(punch_data.playerName, "ws_story:survivor", msg, true)
         end,
     })
+    --]]
 end
 
 -- Enhanced dew barrel system with progression
@@ -291,6 +294,8 @@ local resource_discoveries = {
 }
 
 for item, message in pairs(resource_discoveries) do
+    ---#FIXME
+    --[[
     triggers.register_on_craft({
         target = item,
         id = "ws_story:discover_" .. item,
@@ -299,6 +304,7 @@ for item, message in pairs(resource_discoveries) do
             entries.add_entry(data.playerName, "ws_story:survivor", message, true)
         end,
     })
+    --]]
 end
 
 -- New: Weather and time-based entries
@@ -336,6 +342,8 @@ local milestones = {
 }
 
 for item, message in pairs(milestones) do
+    ---#FIXME
+    --[[
     triggers.register_on_craft({
         target = item,
         id = "ws_story:milestone_" .. item,
@@ -345,6 +353,7 @@ for item, message in pairs(milestones) do
                 "Milestone reached: " .. message, true)
         end,
     })
+    --]]
 end
 
 -- Cleanup on player leave

--- a/mods/ws_tech/init.lua
+++ b/mods/ws_tech/init.lua
@@ -266,8 +266,8 @@ function tech.research_technology(player_name, tech_id)
     
     -- Achievement integration
     if minetest.get_modpath("ws_achievements") then
-        if not achievements.has_achievement(player_name, "first_research") then
-            achievements.grant_achievement(player_name, "first_research")
+        if not ws_achievements.has_achievement(player_name, "first_research") then
+            ws_achievements.grant_achievement(player_name, "first_research")
         end
     end
     
@@ -280,7 +280,8 @@ minetest.register_node("ws_tech:research_table", {
     tiles = {"ws_tech_research_table_top.png", "ws_tech_research_table_bottom.png", 
              "ws_tech_research_table_side.png"},
     groups = {cracky = 2, oddly_breakable_by_hand = 1},
-    sounds = default.node_sound_wood_defaults(),
+    ---#FIXME
+    sounds = ((rawget(_G, "default") and default.node_sound_wood_defaults()) or {}),
     
     on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
         local player_name = clicker:get_player_name()
@@ -391,16 +392,16 @@ minetest.register_on_joinplayer(function(player)
     tech.get_player_research(player_name) -- Initialize research data
 end)
 
--- Achievements integration
+-- ws_achievements integration
 if minetest.get_modpath("ws_achievements") then
-    achievements.register_achievement("first_research", {
+    ws_achievements.register_achievement("first_research", {
         title = "Mad Scientist",
         description = "Research your first technology",
         category = "crafting",
         icon = "ws_achievements_research.png"
     })
     
-    achievements.register_achievement("tech_master", {
+    ws_achievements.register_achievement("tech_master", {
         title = "Tech Master",
         description = "Research 10 different technologies",
         category = "crafting", 

--- a/mods/ws_tech/mod.conf
+++ b/mods/ws_tech/mod.conf
@@ -1,0 +1,3 @@
+name = ws_tech
+description =
+optional_depends = ws_achievements


### PR DESCRIPTION
I offer these changes also under [0BSD](https://opensource.org/license/0bsd) just to avoid licensing issues. You may want these changes or may not, but I highly recommend keeping the game in a runnable state at all times, or else you're flying blind and will just be accumulating errors and bad design that will be a monumental task to fix later that you won't do because it's so huge and demotivating.

## Changes:
- fixed several dependency breakages by adding `mod.conf` and `optional_depends`
- commented out broken API calls to `triggers` (`triggers.register_on_craft`) and added `#FIXME`s (would need larger fixes)
- replaced a call to `default` (sounds) with a conditional so it doesn't crash
- replaced `achievements` (doesn't exist) with `ws_achievements` (does exist)

# Notes
The calls to `triggers.register_on_craft` broke because `def.id` gets referenced as an item by a function in `modutil`. Uncomment one of these calls to see the error:
```
[...]/.minetest/games/WasteLands-Survival/mods/ws_story/init.lua:
...ames/WasteLands-Survival/mods/modutil/check_prefix.venus:22: Name ws_story:milestone_default:chest does not follow naming conventions: contains unallowed characters
stack traceback:
	[C]: in function 'error'
	...ames/WasteLands-Survival/mods/modutil/check_prefix.venus:22: in function 'cmp'
	...Lands-Survival/mods/journal_modpack/journal/triggers.lua:133: in function 'register_on_craft'
	...inetest/games/WasteLands-Survival/mods/ws_story/init.lua:347: in main chunk
```
`modutil` should *not* be causing this error, but it's likely all parts of the chain are wrongly coded:
- `modutil` shouldn't error like this
- `triggers` almost certainly shouldn't call `cmp` in the first place
- the call to `triggers.register_on_craft` probably shouldn't use `id` in this way

Since the purpose of this PR is just "make it load into a world *at all*" I didn't probe further. It's also very obfuscated so doing so would be a nightmare. Even just `triggers` hides its function definitions so you can only access them by manual searching.
